### PR TITLE
dont use railtie initialization 

### DIFF
--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -4,10 +4,6 @@ require 'casclient'
 module RubyCAS
   class Railtie < Rails::Railtie
     config.rubycas = ActiveSupport::OrderedOptions.new
-
-    initializer 'rubycas.initialize' do |app|
-      RubyCAS::Filter.setup(config.rubycas)
-    end
   end
 
   class Filter


### PR DESCRIPTION
I am removing this so that we can use the settings objects to initialize the client.

in your application rb, you would do the following

```
config.after_initialize do
  config.rubycas.cas_base_url = :cas_base_url
  config.rubycas.enable_single_sign_out = :enable_single_sign_out
  RubyCAS::Filter.setup(config.rubycas)
end
```
